### PR TITLE
Override kernel parameters

### DIFF
--- a/mongodb/configure.sls
+++ b/mongodb/configure.sls
@@ -16,6 +16,17 @@ place_mongodb_config_file:
     - watch_in:
       - service: mongodb_service_running
 
+place_mongodb_systemd_overrides:
+  file.managed:
+    - name: /etc/systemd/system/multi-user.target.wants/mongodb.service.d/local.conf
+    - source: salt://mongodb/templates/systemd_local.conf.j2
+    - makedirs: True
+    - template: jinja
+    - context:
+        mongodb_systemd_overrides: {{ mongodb.systemd_overrides }}
+    - watch_in:
+      - service: mongodb_service_running
+
 place_root_user_script:
   file.managed:
     - name: /tmp/create_root.js

--- a/mongodb/map.jinja
+++ b/mongodb/map.jinja
@@ -26,7 +26,17 @@
     },
     'cluster_key_file': '/etc/mongodb_key',
     'install_pkgrepo': True,
-    'service_name': 'mongod'
+    'service_name': 'mongod',
+    'systemd_overrides': {
+      'Service': {
+        'LimitFSIZE': 'infinity',
+        'LimitCPU': 'infinity',
+        'LimitAS': 'infinity',
+        'LimitMEMLOCK': 'infinity',
+        'LimitNOFILE': '64000',
+        'LimitNPROC': '64000'
+      }
+    }
   },
   'Debian': {
     'key': '0C49F3730359A14518585931BC711F9BA15703C6',

--- a/mongodb/templates/systemd_local.conf.j2
+++ b/mongodb/templates/systemd_local.conf.j2
@@ -1,0 +1,6 @@
+{%- for section, settings in mongodb_systemd_overrides.items() %}
+[{{ section }}]
+{%- for k, v in settings.items() %}
+{{ k }}={{ v }}
+{% endfor -%}
+{% endfor -%}


### PR DESCRIPTION
Override kernel parameters that affect MongoDB's connection limits.
See https://docs.mongodb.com/v3.2/reference/ulimit

Related to https://github.com/mitodl/salt-ops/issues/1025

We want to see if increasing these parameters raises the number of available connections reported by `db.serverStatus().connections`.
