### PR TITLE
Ensure dirmngr package is installed if adding pkg repo

### DIFF
--- a/mongodb/repository.sls
+++ b/mongodb/repository.sls
@@ -10,6 +10,14 @@ install_mongodb_gpg_key:
 {% endif %}
 
 {% if mongodb.install_pkgrepo %}
+
+{% if os_family == 'Debian' %}
+ensure_dirmngr_is_installed:
+  pkg.installed:
+    - name: dirnmgr
+    - refresh: True
+{% endif %}
+
 add_mongodb_package_repository:
   pkgrepo.managed:
     - humanname: MongoDB Repository


### PR DESCRIPTION
If the o/s is Debian, ensure that the dirmngr package is installed, if
we are installing via the official MongoDB package repository.

Installing on Debian 9, I get the following error without dirmngr installed:

```
----------
          ID: add_mongodb_package_repository
    Function: pkgrepo.managed
        Name: deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/3.6 main
      Result: False
     Comment: Failed to configure repo 'deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/3.6 main': Error: key retrieval failed: Executing: /tmp/apt-key-gpghome.9dF61ts6YA/gpg.1.sh --batch --keyserver keyserver.ubuntu.com --logger-fd 1 --recv-keys 0C49F3730359A14518585931BC711F9BA15703C6
              gpg: failed to start the dirmngr '/usr/bin/dirmngr': No such file or directory
              gpg: connecting dirmngr at '/tmp/apt-key-gpghome.9dF61ts6YA/S.dirmngr' failed: No such file or directory
              gpg: keyserver receive failed: No dirmngr
     Started: 13:31:35.712009
    Duration: 179.618 ms
     Changes:
```

I'm not sure if we should spend the time at the moment to check what happens with RedHat. What do you think?
