### PR TITLE
Add mongodb-org-tools to packages

### DIFF
--- a/mongodb/map.jinja
+++ b/mongodb/map.jinja
@@ -3,6 +3,7 @@
   'default': {
     'pkgs': [
       'mongodb-org',
+      'mongodb-org-tools'
     ],
     'pip_pkgs': [
       'pymongo',


### PR DESCRIPTION
Without this package, I was getting the following error when debugging a failed installation with `apt-get install mongodb-org`:

```
$ sudo apt-get  install mongodb-org
Reading package lists... Done
Building dependency tree
Reading state information... Done
mongodb-org is already the newest version (3.6.18).
You might want to run 'apt --fix-broken install' to correct these.
The following packages have unmet dependencies:
 mongodb-org : Depends: mongodb-org-tools but it is not going to be installed
E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
```