### PR TITLE
Ensure permissions on logfile for logging agents

### DIFF
--- a/mongodb/configure.sls
+++ b/mongodb/configure.sls
@@ -121,3 +121,12 @@ configure_keyfile_and_replicaset:
     - watch:
         - file: configure_keyfile_and_replicaset
 {% endif %}
+
+# Make sure that the log file can be read by group 'adm' so that logging agents
+# can read it.
+ensure_ownership_and_perms_of_logfile:
+  file.managed:
+    - name: /var/log/mongodb/mongodb.log
+    - user: mongodb
+    - group: adm
+    - mode: 0640

--- a/mongodb/logrotate.sls
+++ b/mongodb/logrotate.sls
@@ -5,7 +5,7 @@ configure_log_rotation:
     - template: jinja
     - mode: '0644'
     - context:
-        name: /var/log/mongodb.log
+        name: /var/log/mongodb/mongodb.log
         options:
           - rotate 4
           - weekly


### PR DESCRIPTION
Ensure that /var/log/mongodb/mongodb.log can be read by logging-related accounts like 'vector', which belong to the 'adm' group.

The file's default ownership is `mongodb:mongodb`, with mode `0600`.
